### PR TITLE
fix(CDNFile): Don't do file_exists check on 'getFullPath' if 'Filename' isn't set.

### DIFF
--- a/code/extensions/CDNFile.php
+++ b/code/extensions/CDNFile.php
@@ -225,6 +225,9 @@ class CDNFile extends DataExtension {
     }
     
     public function localFileExists() {
+    	if (!$this->owner->getField('Filename')) {
+    		return false;
+    	}
         $path = $this->owner->getFullPath();
         if (!file_exists($path) || filesize($path) == 0) {
             return false;


### PR DESCRIPTION
fix(CDNFile): Don't do file_exists check on 'getFullPath' if 'Filename' isn't set.
(Avoids 'assets/' directory returning as an existing file)
