### PR TITLE
fix(CdnImage): Fix resampling to not throw an exception if File::validate() fails on File::write()

### DIFF
--- a/code/dataobjects/CdnImage.php
+++ b/code/dataobjects/CdnImage.php
@@ -40,7 +40,14 @@ class CdnImage extends Image {
                     $samplings = $this->Resamplings->getValues();
                     $samplings[$sampleName] = $samplePointer = $existing->FilePointer;
                     $this->Resamplings = $samplings;
-                    $this->write();
+                    try {
+                        $this->write();
+                    } catch (ValidationException $e) {
+                        // Stops a CMS page from erroring if the file suddenly starts
+                        // failing validation.
+                        // ie. ClamAV detected a virus in File::validate()
+                        SS_Log::log($e, SS_Log::WARN);
+                    }
                 }
             }
 			


### PR DESCRIPTION
fix(CdnImage): Fix resampling to not throw an exception if File::validate() fails on File::write()

Use case: Install ClamAV, File has a virus, throws an exception and causes 500 error on page because CDNImage is trying to resample an infected file that was uploaded before ClamAV was installed.