### PR TITLE
FIX (cdnfile): fix filename path on folder rename for children

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: php
+php:
+ - 5.3
+
+env:
+  matrix:
+   - DB=MYSQL CORE_RELEASE=3.2
+
+matrix:
+  include:
+    - php: 5.3
+      env: DB=MYSQL CORE_RELEASE=3.2
+    - php: 5.4
+      env: DB=MYSQL CORE_RELEASE=3.2
+    - php: 5.5
+      env: DB=MYSQL CORE_RELEASE=3.3
+    - php: 5.6
+      env: DB=MYSQL CORE_RELEASE=3
+    - php: 5.6
+      env: DB=MYSQL CORE_RELEASE=3.2
+    - php: 5.6
+      env: DB=MYSQL CORE_RELEASE=3.3
+    - php: 5.6
+      env: DB=MYSQL CORE_RELEASE=3.4
+    - php: 5.6
+      env: DB=MYSQL CORE_RELEASE=3.5
+
+before_script:
+ - phpenv rehash
+ - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
+ - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
+ - cd ~/builds/ss
+
+script:
+  - vendor/bin/phpunit cdncontent/tests

--- a/code/dataobjects/CdnImage.php
+++ b/code/dataobjects/CdnImage.php
@@ -172,7 +172,7 @@ class CdnImage extends Image {
             $numDeleted++;
         }
         
-        $this->Resamplings = [];
+        $this->Resamplings = array();
         return $numDeleted;
     }
     

--- a/code/extensions/CDNFile.php
+++ b/code/extensions/CDNFile.php
@@ -209,13 +209,14 @@ class CDNFile extends DataExtension {
                 $pathBefore = $changedFields['Filename']['before'];
                 $pathAfter = $changedFields['Filename']['after'];
 
-                if($this->owner instanceof Folder) {
-                    $this->updateChildFolderLinks($this->owner->Children(), $pathBefore, $pathAfter);
-                }
-
                 if($pathBefore && $pathBefore != $pathAfter) {
                     // update links call
                     $this->owner->extend('updateLinks', $pathBefore, $pathAfter);
+
+                    if($this->owner instanceof Folder) {
+                    	$children = Folder::get()->filter('ParentID', $this->owner->ID);
+	                    $this->updateChildFolderLinks($children, $pathBefore, $pathAfter);
+	                }
                 }
             }
 
@@ -227,11 +228,7 @@ class CDNFile extends DataExtension {
     public function updateChildFolderLinks($children, $pathBefore, $pathAfter)
     {
 		foreach($children as $child) {
-			if($child instanceof Folder) {
-				$child->Filename = $pathAfter.$child->Name.'/';
-			} else {
-				$child->Filename = $pathAfter.$child->Name;
-			}
+			$child->Filename = $pathAfter.$child->Name.'/';
 			$child->write();
 		}
     }

--- a/code/extensions/CDNFile.php
+++ b/code/extensions/CDNFile.php
@@ -209,6 +209,10 @@ class CDNFile extends DataExtension {
                 $pathBefore = $changedFields['Filename']['before'];
                 $pathAfter = $changedFields['Filename']['after'];
 
+                if($this->owner instanceof Folder) {
+                    $this->updateChildFolderLinks($this->owner->Children(), $pathBefore, $pathAfter);
+                }
+
                 if($pathBefore && $pathBefore != $pathAfter) {
                     // update links call
                     $this->owner->extend('updateLinks', $pathBefore, $pathAfter);
@@ -220,6 +224,17 @@ class CDNFile extends DataExtension {
         parent::onAfterWrite();
     }
 
+    public function updateChildFolderLinks($children, $pathBefore, $pathAfter)
+    {
+		foreach($children as $child) {
+			if($child instanceof Folder) {
+				$child->Filename = $pathAfter.$child->Name.'/';
+			} else {
+				$child->Filename = $pathAfter.$child->Name;
+			}
+			$child->write();
+		}
+    }
 
     /**
      * And if deleting don't do so

--- a/code/tasks/RepairFolderPathTask.php
+++ b/code/tasks/RepairFolderPathTask.php
@@ -1,0 +1,74 @@
+<?php
+
+class RepairFolderPathTask extends BuildTask
+{
+    public function run($request)
+    {
+        $folderID = $request->getVar('id');
+
+        if($folderID == null || $folderID == '') {
+            echo 'Please enter in a folder ID to repair e.g.: ?id=<id>';
+            return;
+        }
+
+        if(!is_numeric($folderID)) {
+            echo 'FolderID needs to be a valid integer';
+            return;
+        }
+
+        $folderID = (int)$folderID;
+        if(!is_int($folderID)) {
+            echo 'FolderID needs to be a valid integer';
+            return;
+        }
+
+        $folder = Folder::get()->byID($folderID);
+        $fileName = $this->getFixedFolderPath($folder);
+
+        DB::alteration_message("Fixing parent path : '{$folder->Filename}'");
+        DB::alteration_message("Changing to        : '{$fileName}'");
+
+        $folder->Filename = $fileName;
+        $folder->write();
+
+        $children = Folder::get()->filter('ParentID', $folderID);
+        if($children->count() > 0) {
+            DB::alteration_message("Fixed child paths : ");
+            $this->logUpdatedChildren($children, $fileName);
+        }
+
+        DB::alteration_message("");
+    }
+
+    public function getFixedFolderPath($folder)
+    {
+        $folders = [$folder->Name];
+        $parentFolder = $folder->Parent();
+
+        $i = 0;
+        while($parentFolder->Name != null) {
+            array_unshift($folders, $parentFolder->Name);
+            $lastFilename = $parentFolder->Filename;
+            $parentFolder = $parentFolder->Parent();
+        }
+        $baseFilename = $parentFolder->Filename;
+        return $baseFilename.implode('/', $folders).'/';
+    }
+
+    public function logUpdatedChildren($parentChildren, $updatedPath)
+    {
+        foreach($parentChildren as $child) {
+            if(strpos($child->Filename, $updatedPath) !== 0) {
+                $fileName = $this->getFixedFolderPath($child);
+                $child->Filename = $fileName;
+                $child->write();
+            }
+
+            DB::alteration_message("    {$child->Filename}");
+            $children = Folder::get()->filter('ParentID', $child->ID);
+            if($children->count() > 0) {
+                $this->logUpdatedChildren($children, $fileName);
+            }
+        }
+    }
+}

--- a/tests/FolderRenameTest.php
+++ b/tests/FolderRenameTest.php
@@ -1,7 +1,22 @@
 <?php
 
-class TestFolderRename extends SapphireTest
+class FolderRenameTest extends SapphireTest
 {
+	protected $usesDatabase = true;
+
+	public static function setUpBeforeClass()
+	{
+		if(!File::has_extension('CDNFile')) {
+			File::add_extension('CDNFile');
+		}
+
+		if(!Folder::has_extension('CDNFolder')) {
+			Folder::add_extension('CDNFolder');
+		}
+		
+		parent::setUpBeforeClass();
+	}
+
 	public function testFolderRenaming()
 	{
 		$parentFolder = Folder::create();
@@ -16,7 +31,7 @@ class TestFolderRename extends SapphireTest
 		$childFolder = Folder::create();
 		$childFolder->Name = "ChildFolder";
 		$childFolder->Title = "ChildFolder";
-		$childFolder->setParentID($parentFolder->ID);
+		$childFolder->setParentID($parentFolderID);
 		$childFolder->write();
 
 		$this->assertEquals('assets/TestFolder/ChildFolder/', $childFolder->Filename);
@@ -53,5 +68,6 @@ class TestFolderRename extends SapphireTest
 		$childFolder = $parentFolder->Children()->first();
 		$fileCount = $childFolder->Children()->count();
 		$this->assertEquals(2, $fileCount);
+
 	}
 }

--- a/tests/TestFolderRename.php
+++ b/tests/TestFolderRename.php
@@ -1,0 +1,52 @@
+<?php
+
+class TestFolderRename extends SapphireTest
+{
+	public function testFolderRenaming()
+	{
+		$parentFolder = Folder::create();
+		$parentFolder->Name = "TestFolder";
+		$parentFolder->Title = "TestFolder";
+		$parentFolder->write();
+
+		$parentFolderID = $parentFolder->ID;
+
+		$this->assertEquals('assets/TestFolder/', $parentFolder->Filename);
+
+		$childFolder = Folder::create();
+		$childFolder->Name = "ChildFolder";
+		$childFolder->Title = "ChildFolder";
+		$childFolder->setParentID($parentFolder->ID);
+		$childFolder->write();
+
+		$this->assertEquals('assets/TestFolder/ChildFolder/', $childFolder->Filename);
+
+		$tmpFile = File::create();
+		$tmpFile->Name = "TestFile.txt";
+		$tmpFile->Title = "TestFile";
+		$tmpFile->setParentID($childFolder->write());
+		$tmpFile->write();
+
+		$this->assertEquals('assets/TestFolder/ChildFolder/TestFile.txt', $tmpFile->Filename);
+
+		// $parentFolder = Folder::get()->byID($parentFolderID);
+		$parentFolder->Name = "TestFolderRename";
+		$parentFolder->Title = "TestFolderRename";
+		$parentFolder->write();
+
+		$childFolder = $parentFolder->Children()->first();
+		$tmpFile = $childFolder->Children()->first();
+
+		$this->assertEquals('assets/TestFolderRename/', $parentFolder->Filename);
+		$this->assertEquals('assets/TestFolderRename/ChildFolder/', $childFolder->Filename);
+		$this->assertEquals('assets/TestFolderRename/ChildFolder/TestFile.txt', $tmpFile->Filename);
+
+		$newTmpFile = File::create();
+		$newTmpFile->Name = "NewTestFile.txt";
+		$newTmpFile->Title = "NewTestFile";
+		$newTmpFile->setParentID($childFolder->write());
+		$newTmpFile->write();
+
+		$this->assertEquals('assets/TestFolderRename/ChildFolder/NewTestFile.txt', $newTmpFile->Filename);
+	}
+}

--- a/tests/TestFolderRename.php
+++ b/tests/TestFolderRename.php
@@ -29,17 +29,18 @@ class TestFolderRename extends SapphireTest
 
 		$this->assertEquals('assets/TestFolder/ChildFolder/TestFile.txt', $tmpFile->Filename);
 
-		// $parentFolder = Folder::get()->byID($parentFolderID);
+		$parentFolder = Folder::get()->byID($parentFolderID);
 		$parentFolder->Name = "TestFolderRename";
 		$parentFolder->Title = "TestFolderRename";
 		$parentFolder->write();
 
 		$childFolder = $parentFolder->Children()->first();
-		$tmpFile = $childFolder->Children()->first();
 
 		$this->assertEquals('assets/TestFolderRename/', $parentFolder->Filename);
 		$this->assertEquals('assets/TestFolderRename/ChildFolder/', $childFolder->Filename);
-		$this->assertEquals('assets/TestFolderRename/ChildFolder/TestFile.txt', $tmpFile->Filename);
+		// Only enable this for in the future if it's decided that children file filenames should be renamed as well
+		// $tmpFile = $childFolder->Children()->first();
+		// $this->assertEquals('assets/TestFolderRename/ChildFolder/TestFile.txt', $tmpFile->Filename);
 
 		$newTmpFile = File::create();
 		$newTmpFile->Name = "NewTestFile.txt";
@@ -48,5 +49,9 @@ class TestFolderRename extends SapphireTest
 		$newTmpFile->write();
 
 		$this->assertEquals('assets/TestFolderRename/ChildFolder/NewTestFile.txt', $newTmpFile->Filename);
+
+		$childFolder = $parentFolder->Children()->first();
+		$fileCount = $childFolder->Children()->count();
+		$this->assertEquals(2, $fileCount);
 	}
 }


### PR DESCRIPTION
Includes unit test to check when folders are renamed that it cascades to children